### PR TITLE
Prepare to replace walker

### DIFF
--- a/Changes
+++ b/Changes
@@ -1,12 +1,10 @@
 WIP  TBD
 
- * Deprecation: ModeOpaque is now named ModeSingle and will be removed in a
-   future release.
  * Add the Buffer.SetMultipart method for setting the message.BufferMode
    of a message.Buffer to message.ModeMultipart and setting the capacity of the
    internal parts slice.
- * Add the Buffer.SetSingle method for setting the message.BufferMode of a
-   message.Buffer to message.ModeSingle.
+ * Add the Buffer.SetOpaque method for setting the message.BufferMode of a
+   message.Buffer to message.ModeOpaque.
  * Add a linter to check changelog correctness.
  * Add a linter to check for bad patterns in golang.
  * Add tools to manage the release process.

--- a/Changes
+++ b/Changes
@@ -1,5 +1,12 @@
 WIP  TBD
 
+ * Deprecation: ModeOpaque is now named ModeSingle and will be removed in a
+   future release.
+ * Add the Buffer.SetMultipart method for setting the message.BufferMode
+   of a message.Buffer to message.ModeMultipart and setting the capacity of the
+   internal parts slice.
+ * Add the Buffer.SetSingle method for setting the message.BufferMode of a
+   message.Buffer to message.ModeSingle.
  * Add a linter to check changelog correctness.
  * Add a linter to check for bad patterns in golang.
  * Add tools to manage the release process.

--- a/Changes
+++ b/Changes
@@ -1,8 +1,14 @@
 WIP  TBD
 
+ * Deprecation: The OpaqueAlreadyEncoded() method should no longer be used.
+   Instead, call SetEncoded(true) on a mesage.Buffer and then call Opaque() to
+   achive the same result.
+ * Calls to message.Buffer's Opaque() and Multipart() methods are now guaranteed
+   to work if called repeatedly.
  * Add the Buffer.SetMultipart method for setting the message.BufferMode
    of a message.Buffer to message.ModeMultipart and setting the capacity of the
    internal parts slice.
+ * It is now possible to use message.Buffer as a message.Part directly.
  * Add the Buffer.SetOpaque method for setting the message.BufferMode of a
    message.Buffer to message.ModeOpaque.
  * Add a linter to check changelog correctness.

--- a/message/buffer.go
+++ b/message/buffer.go
@@ -20,17 +20,12 @@ const (
 	// ModeUnset indicates that the Buffer has not yet been modified.
 	ModeUnset BufferMode = iota
 
-	// ModeSingle indicates that the Buffer has been used as an io.Writer.
-	ModeSingle
+	// ModeOpaque indicates that the Buffer has been used as an io.Writer.
+	ModeOpaque
 
 	// ModeMultipart indicates that the Buffer has had the parts manipulated.
 	ModeMultipart
 )
-
-// ModeOpaque was the original name for ModeSingle.
-//
-// Deprecated: Use ModeSingle instead.
-const ModeOpaque BufferMode = ModeSingle
 
 var (
 	// ErrPartsBuffer is returned by Write() if that method is called after
@@ -46,7 +41,7 @@ var (
 	ErrModeUnset = errors.New("no message has been built")
 
 	// ErrParsesAsNotMultipart is returned by Multipart() when the Buffer is in
-	// ModeSingle and the message is not at all a *Multipart message.
+	// ModeOpaque and the message is not at all a *Multipart message.
 	ErrParsesAsNotMultipart = errors.New("cannot parse non-multipart message as multipart")
 )
 
@@ -78,14 +73,14 @@ type Buffer struct {
 
 // Mode returns a constant that indicates what mode the Buffer is in. Until a
 // modification method is called, this will return ModeUnset. Once a
-// modification method is called, it will return ModeSingle if the Buffer has
+// modification method is called, it will return ModeOpaque if the Buffer has
 // been used as an io.Writer or ModeMultipart if parts have been added to the
 // Buffer.
 func (b *Buffer) Mode() BufferMode {
 	if b.parts != nil {
 		return ModeMultipart
 	} else if b.buf != nil {
-		return ModeSingle
+		return ModeOpaque
 	}
 	return ModeUnset
 }
@@ -94,7 +89,7 @@ func (b *Buffer) Mode() BufferMode {
 // during message transformation or when you want to pre-allocate the capacity
 // of the internal slice used to hold parts. When calling this method, you need
 // to pass the expected capacity of the multipart message. This will panic if
-// the mode is already ModeSingle.
+// the mode is already ModeOpaque.
 func (b *Buffer) SetMultipart(capacity int) {
 	err := b.initParts(capacity)
 	if err != nil {
@@ -102,10 +97,10 @@ func (b *Buffer) SetMultipart(capacity int) {
 	}
 }
 
-// SetSingle sets the Mode of the buffer to ModeSingle. This is useful during
+// SetOpaque sets the Mode of the buffer to ModeOpaque. This is useful during
 // message transformation, especially if the message content is to be empty.
 // This will panic if the mode is already ModeMultipart.
-func (b *Buffer) SetSingle() {
+func (b *Buffer) SetOpaque() {
 	err := b.initBuffer()
 	if err != nil {
 		panic(err)
@@ -170,7 +165,7 @@ func (b *Buffer) prepareForMultipartOutput() {
 //
 // This method will panic if the BufferMode is ModeUnset.
 //
-// If the BufferMode is ModeSingle, the Header and the bytes written to the
+// If the BufferMode is ModeOpaque, the Header and the bytes written to the
 // internal buffer will be returned in the *Opaque. Opaque will return a MIME
 //
 // If the BufferMode is ModeMultipart, the parts will be serialized into a byte
@@ -193,7 +188,7 @@ func (b *Buffer) prepareForMultipartOutput() {
 // used.
 func (b *Buffer) Opaque() *Opaque {
 	switch b.Mode() {
-	case ModeSingle:
+	case ModeOpaque:
 		return &Opaque{
 			Header: b.Header,
 			Reader: b.buf,
@@ -264,7 +259,7 @@ func (b *Buffer) OpaqueAlreadyEncoded() *Opaque {
 //
 // If the BufferMode is ModeUnset, this method will panic.
 //
-// If the BufferMode is ModeSingle, the bytes that have been written to the
+// If the BufferMode is ModeOpaque, the bytes that have been written to the
 // buffer must be parsed in order to generate the returned *Multipart. In that
 // case, the function will create an *Opaque and use the Parse() function to try
 // to generate a *Multipart. The Parse() function will be called with the
@@ -282,7 +277,7 @@ func (b *Buffer) OpaqueAlreadyEncoded() *Opaque {
 func (b *Buffer) Multipart() (*Multipart, error) {
 	b.prepareForMultipartOutput()
 	switch b.Mode() {
-	case ModeSingle:
+	case ModeOpaque:
 		msg := &Opaque{b.Header, b.buf, false}
 		pr := defaultParser.clone()
 		WithoutRecursion()(pr)

--- a/message/buffer.go
+++ b/message/buffer.go
@@ -189,9 +189,10 @@ func (b *Buffer) prepareForMultipartOutput() {
 func (b *Buffer) Opaque() *Opaque {
 	switch b.Mode() {
 	case ModeOpaque:
+		r := bytes.NewReader(b.buf.Bytes())
 		return &Opaque{
 			Header: b.Header,
-			Reader: b.buf,
+			Reader: r,
 		}
 	case ModeMultipart:
 		b.prepareForMultipartOutput()
@@ -207,9 +208,10 @@ func (b *Buffer) Opaque() *Opaque {
 			_, _ = fmt.Fprintf(buf, "--%s--", boundary)
 		}
 
+		r := bytes.NewReader(buf.Bytes())
 		return &Opaque{
 			Header: b.Header,
-			Reader: buf,
+			Reader: r,
 		}
 	case ModeUnset:
 		panic(ErrModeUnset)
@@ -278,7 +280,8 @@ func (b *Buffer) Multipart() (*Multipart, error) {
 	b.prepareForMultipartOutput()
 	switch b.Mode() {
 	case ModeOpaque:
-		msg := &Opaque{b.Header, b.buf, false}
+		r := bytes.NewReader(b.buf.Bytes())
+		msg := &Opaque{b.Header, r, false}
 		pr := defaultParser.clone()
 		WithoutRecursion()(pr)
 		gmsg, err := pr.parse(msg, 0)

--- a/message/buffer_test.go
+++ b/message/buffer_test.go
@@ -145,7 +145,7 @@ func TestBuffer_Write(t *testing.T) {
 	assert.Equal(t, 33, n)
 	assert.NoError(t, err)
 
-	assert.Equal(t, message.ModeOpaque, buf.Mode())
+	assert.Equal(t, message.ModeSingle, buf.Mode())
 
 	assert.Panics(t, func() {
 		buf.Add(makePart())

--- a/message/buffer_test.go
+++ b/message/buffer_test.go
@@ -3,7 +3,6 @@ package message_test
 import (
 	"bytes"
 	"fmt"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -11,12 +10,11 @@ import (
 	"github.com/zostay/go-email/v2/message"
 )
 
-func makePart() *message.Opaque {
-	op := &message.Opaque{
-		Reader: strings.NewReader("Test message."),
-	}
-	op.SetMediaType("text/html")
-	return op
+func makePart() *message.Buffer {
+	buf := &message.Buffer{}
+	buf.SetMediaType("text/html")
+	_, _ = fmt.Fprintf(buf, "Test message.")
+	return buf
 }
 
 func makeSimple() (*message.Buffer, string, error) {
@@ -307,6 +305,21 @@ func TestBuffer_OpaqueMultipleCopies(t *testing.T) {
 	t.Parallel()
 
 	s, expect, err := makeSimple()
+	assert.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		buf := &bytes.Buffer{}
+		op := s.Opaque()
+		_, err = op.WriteTo(buf)
+		assert.NoErrorf(t, err, "no error #%d", i)
+		assert.Equalf(t, []byte(expect), buf.Bytes(), "expected buffer #%d", i)
+	}
+}
+
+func TestBuffer_MultipartMultipleCopies(t *testing.T) {
+	t.Parallel()
+
+	s, expect, err := makeMultipart()
 	assert.NoError(t, err)
 
 	for i := 0; i < 5; i++ {

--- a/message/buffer_test.go
+++ b/message/buffer_test.go
@@ -145,7 +145,7 @@ func TestBuffer_Write(t *testing.T) {
 	assert.Equal(t, 33, n)
 	assert.NoError(t, err)
 
-	assert.Equal(t, message.ModeSingle, buf.Mode())
+	assert.Equal(t, message.ModeOpaque, buf.Mode())
 
 	assert.Panics(t, func() {
 		buf.Add(makePart())

--- a/message/buffer_test.go
+++ b/message/buffer_test.go
@@ -302,3 +302,18 @@ func TestBuffer_Multipart_FromOpaqueMultipart(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, expect, buf.String())
 }
+
+func TestBuffer_OpaqueMultipleCopies(t *testing.T) {
+	t.Parallel()
+
+	s, expect, err := makeSimple()
+	assert.NoError(t, err)
+
+	for i := 0; i < 5; i++ {
+		buf := &bytes.Buffer{}
+		op := s.Opaque()
+		_, err = op.WriteTo(buf)
+		assert.NoErrorf(t, err, "no error #%d", i)
+		assert.Equalf(t, []byte(expect), buf.Bytes(), "expected buffer #%d", i)
+	}
+}

--- a/message/opaque_test.go
+++ b/message/opaque_test.go
@@ -96,7 +96,8 @@ func TestOpaque_TransferEncodingDecoded(t *testing.T) {
 	// This is actually wrong since the data created by makeSimpleWithEncoding
 	// is not encoded. However, we just want to test that no encoding is
 	// performed if we all OpaqueAlreadyEncoded.
-	m := buf.OpaqueAlreadyEncoded()
+	buf.SetEncoded(true)
+	m := buf.Opaque()
 
 	assert.Equal(t, &m.Header, m.GetHeader())
 


### PR DESCRIPTION
The main change is that message.Buffer is now a message.Part. This is in preparation for replacing walker.